### PR TITLE
Curse typing controller

### DIFF
--- a/curse_casting/curse_controller.gd
+++ b/curse_casting/curse_controller.gd
@@ -1,0 +1,36 @@
+# File creator: A.P.
+extends Node
+
+enum CurseState {ACTIVE, NON_ACTIVE}
+
+var state: int = CurseState.NON_ACTIVE
+var text: String = ""
+
+func _ready():
+	set_process_unhandled_key_input(false)
+
+# Curse input is handled here
+func _process(delta):
+	# Start a curse
+	if Input.is_action_just_pressed("start_curse") && state == CurseState.NON_ACTIVE:
+		state = CurseState.ACTIVE
+		set_process_unhandled_key_input(true)
+	# End a curse
+	elif Input.is_action_just_pressed("end_curse") && state == CurseState.ACTIVE:
+		state = CurseState.NON_ACTIVE
+		set_process_unhandled_key_input(false)
+		
+		# Check if text is a correct curse
+		if valid_curse(text.to_lower()):
+			print("Cast " + text)
+		text = ""
+
+func _unhandled_key_input(event):
+	if event is InputEventKey:
+		if event.pressed and !event.is_action("end_curse"):
+			text += event.as_text_key_label()
+			print(text)
+
+# Return whether text is a valid curse
+func valid_curse(curse):
+	return $"/root/GlobalVariables".curse_words.has(curse)

--- a/curse_casting/curse_controller.tscn
+++ b/curse_casting/curse_controller.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bfitc7nf8btyu"]
+
+[ext_resource type="Script" path="res://curse_casting/curse_controller.gd" id="1_l1rnd"]
+
+[node name="CurseController" type="Node"]
+script = ExtResource("1_l1rnd")

--- a/global_variables.gd
+++ b/global_variables.gd
@@ -1,0 +1,3 @@
+extends Node
+
+var curse_words: Array = ["fear", "tear", "taste"]

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,23 @@ config_version=5
 
 config/name="CUJamSept24"
 config/features=PackedStringArray("4.3", "GL Compatibility")
-config/icon="res://icon.svg"
+
+[autoload]
+
+GlobalVariables="*res://global_variables.gd"
+
+[input]
+
+start_curse={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}
+end_curse={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 


### PR DESCRIPTION
Beginnings of the curse typing controller.

Currently, typing E will start curse typing, and then hitting space will end curse typing. The mouse mini-game should begin if a valid curse is entered. For now there are no visuals and no mouse mini game. Everything is just printed to the console.